### PR TITLE
Add Script | install-or-update-with-alectrona-patch-agnosticMDM.sh

### DIFF
--- a/install-alectrona-patch.sh
+++ b/install-alectrona-patch.sh
@@ -10,6 +10,20 @@ uuid=$(/usr/bin/uuidgen)
 workDir="/private/tmp/$uuid"
 unset version
 
+# Proxy variable
+proxyUrl=""
+# Jamf Pro variable for proxyUrl
+if [[ "$4" != "" ]]; then
+    proxyUrl="$4"
+fi
+
+# Set proxy param for curl
+if [[ "$proxyUrl" != "" ]]; then
+    curlProxyUrl="--proxy $proxyUrl"
+else
+    curlProxyUrl=""
+fi
+
 function clean_up () {
     echo "Cleaning up installation files..."
     /bin/rm -Rf "$workDir"
@@ -23,7 +37,7 @@ trap clean_up EXIT
 
 # Exit if there was an error with the curl
 echo "Downloading the installation files..."
-if ! /usr/bin/curl -s -L -f https://software.alectrona.com/patch/releases/alectrona-patch-latest.pkg -o "$workDir/alectrona-patch.pkg" ; then
+if ! /usr/bin/curl $curlProxyUrl -s -L -f https://software.alectrona.com/patch/releases/alectrona-patch-latest.pkg -o "$workDir/alectrona-patch.pkg" ; then
     echo "Error while downloading the installation files; exiting."
     exit 1
 fi

--- a/install-or-update-with-alectrona-patch-agnosticMDM.sh
+++ b/install-or-update-with-alectrona-patch-agnosticMDM.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Install or Update with Alectrona Patch
+
+# A script to Install or Update a software title with Alectrona Patch with an MDM that doesn't have a local binary, like Mosyle Business or Meraki Systems Manager.
+
+softwareID=""        # The Software ID of the application
+options=""              # The various command line arguments (--force|--update-only|--silent etc.)
+ignorePatchErrors="false" # Ignore Patch Errors (true|false)
+
+# If Alectrona Patch is not installed, install it using a Jamf policy trigger of "alectrona-patch"
+function clean_up() {
+    echo "Cleaning up installation files..."
+    /bin/rm -Rf "$workDir"
+}
+
+if [[ ! -e /usr/local/bin/patch ]]; then
+    uuid=$(/usr/bin/uuidgen)
+    workDir="/private/tmp/$uuid"
+    unset version
+
+    # Clean up our temporary files upon exiting at any time
+    trap clean_up EXIT
+
+    # Make our working directory with our unique UUID generated in the variables section
+    /bin/mkdir -p "$workDir"
+
+    # Exit if there was an error with the curl
+    echo "Downloading the installation files..."
+    if ! /usr/bin/curl -s -L -f https://software.alectrona.com/patch/releases/alectrona-patch-latest.pkg -o "$workDir/alectrona-patch.pkg"; then
+        echo "Error while downloading the installation files; exiting."
+        exit 1
+    fi
+
+    # Exit if the PKG errored during install
+    if ! /usr/sbin/installer -pkg "$workDir/alectrona-patch.pkg" -target /; then
+        echo "Failed to install the pkg; exiting."
+        exit 2
+    fi
+
+    # Exit if we can't determine the version of patch
+    version=$(/usr/local/bin/patch --version 2>/dev/null)
+    if [[ -n "$version" ]]; then
+        echo "Successfully installed Alectrona Patch version $version."
+    else
+        echo "Failed to successfully install Alectrona Patch; exiting."
+        exit 3
+    fi
+fi
+
+# Run the patch binary with the software ID and options
+# Not quoting the options as we want to word-split
+/usr/local/bin/patch install -s "$softwareID" "$options"
+result="$?"
+
+if [[ "$ignorePatchErrors" == "true" ]]; then
+    exit 0
+else
+    exit "$result"
+fi

--- a/install-or-update-with-alectrona-patch-agnosticMDM.sh
+++ b/install-or-update-with-alectrona-patch-agnosticMDM.sh
@@ -4,6 +4,8 @@
 
 # A script to Install or Update a software title with Alectrona Patch with an MDM that doesn't have a local binary, like Mosyle Business or Meraki Systems Manager.
 
+# Script compiled by @hkystar35 from combo of Alectrona Patch scripts to use in agnostic MDM setup
+
 softwareID=""        # The Software ID of the application
 options=""              # The various command line arguments (--force|--update-only|--silent etc.)
 ignorePatchErrors="false" # Ignore Patch Errors (true|false)

--- a/install-or-update-with-alectrona-patch-agnosticMDM.sh
+++ b/install-or-update-with-alectrona-patch-agnosticMDM.sh
@@ -4,7 +4,7 @@
 
 # A script to Install or Update a software title with Alectrona Patch with an MDM that doesn't have a local binary, like Mosyle Business or Meraki Systems Manager.
 
-softwareID=""        # The Software ID of the application
+softwareID="dockutil"        # The Software ID of the application
 options=""              # The various command line arguments (--force|--update-only|--silent etc.)
 ignorePatchErrors="false" # Ignore Patch Errors (true|false)
 
@@ -50,7 +50,7 @@ fi
 
 # Run the patch binary with the software ID and options
 # Not quoting the options as we want to word-split
-/usr/local/bin/patch install -s "$softwareID" "$options"
+/usr/local/bin/patch install -s "$softwareID" $options
 result="$?"
 
 if [[ "$ignorePatchErrors" == "true" ]]; then

--- a/install-or-update-with-alectrona-patch-agnosticMDM.sh
+++ b/install-or-update-with-alectrona-patch-agnosticMDM.sh
@@ -4,7 +4,7 @@
 
 # A script to Install or Update a software title with Alectrona Patch with an MDM that doesn't have a local binary, like Mosyle Business or Meraki Systems Manager.
 
-softwareID="dockutil"        # The Software ID of the application
+softwareID=""        # The Software ID of the application
 options=""              # The various command line arguments (--force|--update-only|--silent etc.)
 ignorePatchErrors="false" # Ignore Patch Errors (true|false)
 


### PR DESCRIPTION
Submitting new install script for use with MDM that does not have local binary but still checks for Alectrona Patch installation first.